### PR TITLE
Fix product filtering by approval and activity

### DIFF
--- a/client/src/components/ProductsGrid.tsx
+++ b/client/src/components/ProductsGrid.tsx
@@ -55,6 +55,8 @@ const ProductsGrid: React.FC<ProductsGridProps> = ({ pageSize = 12 }) => {
       const { data, error: fetchError, count } = await supabase
         .from('products')
         .select('*', { count: 'exact' })
+        .eq('is_active', true)
+        .eq('is_approved', true)
         .range(startIndex, endIndex)
         .order('created_at', { ascending: false })
 


### PR DESCRIPTION
## Summary
- only show approved and active products in `ProductsGrid`

## Testing
- `npm run check` *(fails: Cannot find type definition file, missing dependencies)*
- `npm install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6886e5fea98c83268b408a58962c270e