### PR TITLE
Add design data to order items

### DIFF
--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -85,10 +85,12 @@ export interface OrderItem {
   id: string
   order_id: string
   product_id: string
+  design_id?: string | null
   quantity: number
   unit_price: number
   total_price: number
   options?: any // JSON object
+  design_data?: any
   created_at: string
 }
 

--- a/client/src/lib/supabaseApi.ts
+++ b/client/src/lib/supabaseApi.ts
@@ -1319,6 +1319,28 @@ export const createOrder = async (userId: string, cartItems: any[]) => {
       throw orderError;
     }
 
+    const orderItems = cartItems.map(item => ({
+      order_id: order.id,
+      product_id: item.product_id,
+      design_id: item.design_id,
+      quantity: item.quantity,
+      unit_price: item.price || item.products?.base_price || 0,
+      total_price: (item.price || item.products?.base_price || 0) * item.quantity,
+      options: item.options,
+      design_data: item.design_data
+    }));
+
+    if (orderItems.length > 0) {
+      const { error: orderItemsError } = await supabase
+        .from('order_items')
+        .insert(orderItems);
+
+      if (orderItemsError) {
+        console.error('Error creating order items:', orderItemsError);
+        // Do not throw here to avoid failing the whole order creation
+      }
+    }
+
     // Create print jobs for each item
     const printJobs = cartItems.map(item => ({
       order_id: order.id,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -657,8 +657,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
         product_id: item.product_id,
         design_id: item.design_id,
         quantity: item.quantity,
-        price: item.price,
-        options: item.options
+        unit_price: item.price,
+        total_price: item.price * item.quantity,
+        options: item.options,
+        design_data: item.design_data,
       }));
       
       const { error: itemsError } = await supabase

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -76,6 +76,7 @@ CREATE TABLE order_items (
     unit_price DECIMAL(10,2) NOT NULL,
     total_price DECIMAL(10,2) NOT NULL,
     options JSONB,
+    design_data JSONB,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT now()
 );
 


### PR DESCRIPTION
## Summary
- extend `order_items` table with `design_data` JSONB
- track design info in `OrderItem` interface
- save design data when creating orders
- include design info in order creation endpoint

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_688783b985c48326859ed9288bbdbb3f