### PR TITLE
Display options and design preview on order detail

### DIFF
--- a/client/src/pages/OrderDetail.tsx
+++ b/client/src/pages/OrderDetail.tsx
@@ -361,26 +361,54 @@ export default function OrderDetail() {
                 {order.order_items && order.order_items.length > 0 ? (
                   <div className="space-y-4">
                     {order.order_items.map((item: any, index: number) => (
-                      <div key={index} className="flex items-center justify-between p-4 border rounded-lg dark:border-gray-700">
-                        <div className="flex items-center space-x-4">
+                      <div
+                        key={index}
+                        className="flex items-start justify-between p-4 border rounded-lg dark:border-gray-700"
+                      >
+                        <div className="flex items-start space-x-4">
                           <div className="w-16 h-16 bg-gray-200 dark:bg-[#1a1a1a] rounded-lg flex items-center justify-center">
                             <Package className="h-8 w-8 text-gray-400" />
                           </div>
                           <div>
                             <h3 className="font-medium text-gray-900 dark:text-white">
-                              {item.productName || `상품 ${index + 1}`}
+                              {item.productName || item.products?.name_ko || `상품 ${index + 1}`}
                             </h3>
                             <p className="text-sm text-gray-600 dark:text-gray-300">
                               수량: {item.quantity}개
                             </p>
+                            {Array.isArray(item.options) && item.options.length > 0 && (
+                              <ul className="mt-1 text-sm text-gray-700 dark:text-gray-300">
+                                {item.options.map((opt: any) => (
+                                  <li key={opt.name}>
+                                    <strong>{opt.name}</strong>: {opt.value}
+                                  </li>
+                                ))}
+                              </ul>
+                            )}
+                            {item.design_data?.imageUrl && (
+                              <div className="mt-2">
+                                <img
+                                  src={item.design_data.imageUrl}
+                                  alt="디자인 미리보기"
+                                  className="w-60 border rounded"
+                                />
+                              </div>
+                            )}
+                            {item.design_data && !item.design_data.imageUrl && (
+                              <div className="mt-2 bg-gray-100 dark:bg-[#1a1a1a] p-2 rounded">
+                                <pre className="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+                                  {JSON.stringify(item.design_data, null, 2)}
+                                </pre>
+                              </div>
+                            )}
                           </div>
                         </div>
                         <div className="text-right">
                           <p className="text-lg font-semibold text-gray-900 dark:text-white">
-                            {formatPrice(item.price * item.quantity)}
+                            {formatPrice((item.price || item.unit_price || 0) * item.quantity)}
                           </p>
                           <p className="text-sm text-gray-600 dark:text-gray-300">
-                            개당 {formatPrice(item.price)}
+                            개당 {formatPrice(item.price || item.unit_price || 0)}
                           </p>
                         </div>
                       </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3653,14 +3653,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/orders/:id", async (req, res) => {
     try {
       const orderId = parseInt(req.params.id);
-      
+
       if (isNaN(orderId)) {
         return res.status(400).json({ message: '유효하지 않은 주문 ID입니다.' });
       }
 
       const { data: order, error } = await supabase
         .from('orders')
-        .select('*')
+        .select(`
+          *,
+          order_items (
+            *,
+            products (
+              id, name, name_ko, image_url
+            ),
+            goods_editor_designs (
+              id, title, thumbnail_url, canvas_data
+            )
+          )
+        `)
         .eq('id', orderId)
         .single();
 


### PR DESCRIPTION
## Summary
- include `order_items` and related data when fetching single order
- render option list and design preview in the order detail page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6887872116008326b5802b541918e110